### PR TITLE
#[\Override]: document restriction on __construct()

### DIFF
--- a/language/predefined/attributes/override.xml
+++ b/language/predefined/attributes/override.xml
@@ -17,6 +17,11 @@
     in an implemented interface a compile-time error will be
     emitted.
    </simpara>
+   <simpara>
+    The attribute cannot be used on a
+    <link linkend="object.construct">__construct()</link>
+    method.
+   </simpara>
   </section>
 
   <section xml:id="override.synopsis">


### PR DESCRIPTION
Prompted by a note on the manual page